### PR TITLE
Start exporting library

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
-// firefly Library 
-export * from "@firefly-exchange/library-sui"
+// firefly Library
+export * from "@firefly-exchange/library-sui";
 // interfaces
 export * from "./src/interfaces/routes";
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+// firefly Library 
+export * from "@firefly-exchange/library-sui"
 // interfaces
 export * from "./src/interfaces/routes";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/bluefin-v2-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The Bluefin client Library allows traders to sign, create, retrieve and listen to orders on Bluefin Exchange.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/bluefin-v2-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The Bluefin client Library allows traders to sign, create, retrieve and listen to orders on Bluefin Exchange.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/bluefin-v2-client",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "The Bluefin client Library allows traders to sign, create, retrieve and listen to orders on Bluefin Exchange.",
   "main": "dist/index.js",
   "scripts": {

--- a/public/package.json
+++ b/public/package.json
@@ -6,7 +6,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@bluefin-exchange/bluefin-v2-client": "^1.0.1"
+    "@bluefin-exchange/bluefin-v2-client": "^1.0.3"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/public/package.json
+++ b/public/package.json
@@ -6,7 +6,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@bluefin-exchange/bluefin-v2-client": "^1.0.3"
+    "@bluefin-exchange/bluefin-v2-client": "^2.0.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/public/package.json
+++ b/public/package.json
@@ -8,8 +8,7 @@
     "adjust-margin": "ts-node ./src/examples/10.adjust_margin.ts"
   },
   "dependencies": {
-    "@bluefin-exchange/bluefin-v2-client": "^1.0.1",
-    "@firefly-exchange/library-sui": "^0.1.48"
+    "@bluefin-exchange/bluefin-v2-client": "^1.0.1"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/public/src/examples/10.adjust_margin.ts
+++ b/public/src/examples/10.adjust_margin.ts
@@ -4,7 +4,11 @@
 
 /* eslint-disable no-console */
 
-import { BluefinClient, Networks ,ADJUST_MARGIN} from "@bluefin-exchange/bluefin-v2-client";
+import {
+  BluefinClient,
+  Networks,
+  ADJUST_MARGIN,
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/10.adjust_margin.ts
+++ b/public/src/examples/10.adjust_margin.ts
@@ -4,8 +4,7 @@
 
 /* eslint-disable no-console */
 
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
-import { ADJUST_MARGIN } from "@firefly-exchange/library-sui";
+import { BluefinClient, Networks ,ADJUST_MARGIN} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/11.get_user_orders.ts
+++ b/public/src/examples/11.get_user_orders.ts
@@ -1,8 +1,11 @@
 /**
  *  Query user orders
  **/
-import { BluefinClient, Networks, ORDER_STATUS } from "@bluefin-exchange/bluefin-v2-client";
-
+import {
+  BluefinClient,
+  Networks,
+  ORDER_STATUS,
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/11.get_user_orders.ts
+++ b/public/src/examples/11.get_user_orders.ts
@@ -1,8 +1,8 @@
 /**
  *  Query user orders
  **/
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
-import { ORDER_STATUS } from "@firefly-exchange/library-sui";
+import { BluefinClient, Networks, ORDER_STATUS } from "@bluefin-exchange/bluefin-v2-client";
+
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/4.create_signed_order.ts
+++ b/public/src/examples/4.create_signed_order.ts
@@ -6,7 +6,12 @@
 
 /* eslint-disable no-console */
 
-import { ORDER_SIDE, ORDER_TYPE, BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+import {
+  ORDER_SIDE,
+  ORDER_TYPE,
+  BluefinClient,
+  Networks,
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   // no gas fee is required to create order signature.

--- a/public/src/examples/4.create_signed_order.ts
+++ b/public/src/examples/4.create_signed_order.ts
@@ -5,8 +5,8 @@
  */
 
 /* eslint-disable no-console */
-import { ORDER_SIDE, ORDER_TYPE } from "@firefly-exchange/library-sui";
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+
+import { ORDER_SIDE, ORDER_TYPE, BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   // no gas fee is required to create order signature.

--- a/public/src/examples/5.post_order.ts
+++ b/public/src/examples/5.post_order.ts
@@ -4,7 +4,12 @@
  */
 
 /* eslint-disable no-console */
-import { ORDER_SIDE, ORDER_TYPE,BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+import {
+  ORDER_SIDE,
+  ORDER_TYPE,
+  BluefinClient,
+  Networks,
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/5.post_order.ts
+++ b/public/src/examples/5.post_order.ts
@@ -4,8 +4,7 @@
  */
 
 /* eslint-disable no-console */
-import { ORDER_SIDE, ORDER_TYPE } from "@firefly-exchange/library-sui";
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+import { ORDER_SIDE, ORDER_TYPE,BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/6.create_cancel_order.ts
+++ b/public/src/examples/6.create_cancel_order.ts
@@ -3,18 +3,11 @@
  */
 
 /* eslint-disable no-console */
+
 import {
-  ORDER_STATUS,
   ORDER_SIDE,
-  ORDER_TYPE,
-  toBaseNumber,
-  MinifiedCandleStick,
-  Faucet,
-  OrderSigner,
-  parseSigPK,
-  ADJUST_MARGIN,
-} from "@firefly-exchange/library-sui";
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+  ORDER_TYPE, BluefinClient, Networks
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/6.create_cancel_order.ts
+++ b/public/src/examples/6.create_cancel_order.ts
@@ -6,7 +6,9 @@
 
 import {
   ORDER_SIDE,
-  ORDER_TYPE, BluefinClient, Networks
+  ORDER_TYPE,
+  BluefinClient,
+  Networks,
 } from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {

--- a/public/src/examples/7.post_cancel_order.ts
+++ b/public/src/examples/7.post_cancel_order.ts
@@ -3,18 +3,11 @@
  */
 
 /* eslint-disable no-console */
+
 import {
-  ORDER_STATUS,
   ORDER_SIDE,
-  ORDER_TYPE,
-  toBaseNumber,
-  MinifiedCandleStick,
-  Faucet,
-  OrderSigner,
-  parseSigPK,
-  ADJUST_MARGIN,
-} from "@firefly-exchange/library-sui";
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+  ORDER_TYPE, BluefinClient, Networks
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/7.post_cancel_order.ts
+++ b/public/src/examples/7.post_cancel_order.ts
@@ -6,7 +6,9 @@
 
 import {
   ORDER_SIDE,
-  ORDER_TYPE, BluefinClient, Networks
+  ORDER_TYPE,
+  BluefinClient,
+  Networks,
 } from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {

--- a/public/src/examples/8.cancel_all_open_orders.ts
+++ b/public/src/examples/8.cancel_all_open_orders.ts
@@ -3,18 +3,11 @@
  */
 
 /* eslint-disable no-console */
+
 import {
-  ORDER_STATUS,
   ORDER_SIDE,
-  ORDER_TYPE,
-  toBaseNumber,
-  MinifiedCandleStick,
-  Faucet,
-  OrderSigner,
-  parseSigPK,
-  ADJUST_MARGIN,
-} from "@firefly-exchange/library-sui";
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
+  ORDER_TYPE, BluefinClient, Networks
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/8.cancel_all_open_orders.ts
+++ b/public/src/examples/8.cancel_all_open_orders.ts
@@ -6,7 +6,9 @@
 
 import {
   ORDER_SIDE,
-  ORDER_TYPE, BluefinClient, Networks
+  ORDER_TYPE,
+  BluefinClient,
+  Networks,
 } from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {

--- a/public/src/examples/sockets/1.candlestick.ts
+++ b/public/src/examples/sockets/1.candlestick.ts
@@ -1,7 +1,11 @@
 /**
  * Client initialization code example
  */
-import { BluefinClient, Networks, MinifiedCandleStick} from "@bluefin-exchange/bluefin-v2-client";
+import {
+  BluefinClient,
+  Networks,
+  MinifiedCandleStick,
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/sockets/1.candlestick.ts
+++ b/public/src/examples/sockets/1.candlestick.ts
@@ -1,8 +1,7 @@
 /**
  * Client initialization code example
  */
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
-import { MinifiedCandleStick } from "@firefly-exchange/library-sui";
+import { BluefinClient, Networks, MinifiedCandleStick} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/sockets/2.ordersocket.ts
+++ b/public/src/examples/sockets/2.ordersocket.ts
@@ -1,7 +1,12 @@
 /**
  * Client initialization code example
  */
-import { BluefinClient, Networks, ORDER_SIDE, ORDER_TYPE } from "@bluefin-exchange/bluefin-v2-client";
+import {
+  BluefinClient,
+  Networks,
+  ORDER_SIDE,
+  ORDER_TYPE,
+} from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/src/examples/sockets/2.ordersocket.ts
+++ b/public/src/examples/sockets/2.ordersocket.ts
@@ -1,8 +1,7 @@
 /**
  * Client initialization code example
  */
-import { BluefinClient, Networks } from "@bluefin-exchange/bluefin-v2-client";
-import { ORDER_SIDE, ORDER_TYPE } from "@firefly-exchange/library-sui";
+import { BluefinClient, Networks, ORDER_SIDE, ORDER_TYPE } from "@bluefin-exchange/bluefin-v2-client";
 
 async function main() {
   const dummyAccountKey =

--- a/public/yarn.lock
+++ b/public/yarn.lock
@@ -1048,7 +1048,7 @@
     yargs "^17.6.2"
     yarn "^1.22.19"
 
-"@firefly-exchange/library-sui@^0.1.47", "@firefly-exchange/library-sui@^0.1.48":
+"@firefly-exchange/library-sui@^0.1.47":
   version "0.1.48"
   resolved "https://registry.yarnpkg.com/@firefly-exchange/library-sui/-/library-sui-0.1.48.tgz#2380fbc43b41de038a68a17f72efaff8730f00d0"
   integrity sha512-Jb7GoALdlo+hV7MckABS0UD3vCqHrFYfxUbqCwtw6lh/wV4UxwIhnIHXxw26jLn9IwKtsA22niDPixQXp93Nxw==

--- a/src/bluefinClient.ts
+++ b/src/bluefinClient.ts
@@ -384,7 +384,7 @@ export class BluefinClient {
       orderType: order.orderType,
       triggerPrice:
         order.orderType === ORDER_TYPE.STOP_MARKET ||
-          order.orderType === ORDER_TYPE.LIMIT
+        order.orderType === ORDER_TYPE.LIMIT
           ? order.triggerPrice || 0
           : 0,
       postOnly: orderToSign.postOnly,

--- a/src/interfaces/routes.ts
+++ b/src/interfaces/routes.ts
@@ -486,14 +486,14 @@ export interface GetCountDownsResponse {
   timestamp: number;
 }
 
-export interface Network {
+export interface NetworkConfigs {
   name?: string;
   rpc?: string;
   faucet?: string;
   url?: string;
 }
 // adding this here as it's temporary support for socket.io
-export interface ExtendedNetwork extends Network {
+export interface ExtendedNetwork extends NetworkConfigs {
   apiGateway?: string; // making it optional for backward compatibility
   socketURL?: string;
   onboardingUrl?: string;


### PR DESCRIPTION
- Starting Exporting `Library-sui` from index.ts to avoid importing library by client users.
- Rename `Network` interface in client to `NetworkConfigs`. This is because library also contains `Network` interface and client can not export 2 similar interfces in `index.ts`
- Fixed Examples
- Updated the version