### PR TITLE
Prerelease/action

### DIFF
--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -1,0 +1,49 @@
+name: PR Checks
+
+on:
+  push:
+    branches:
+      - 'prerelease/**'
+
+jobs:
+  code-format:
+    name: Code Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        name: Setup Node.js
+        with:
+          node-version: "18.x"
+      - name: Setup yarn
+        run: npm install -g yarn
+      - run: yarn
+      - run: yarn ci:code-formatting
+  code-style:
+    name: Code Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        name: Setup Node.js
+        with:
+          node-version: "18.x"
+      - name: Setup yarn
+        run: npm install -g yarn
+      - run: yarn
+      - run: yarn ci:code-style
+  build:
+    name: build check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        name: Setup Node.js
+        with:
+          node-version: "18.x"
+      - name: Setup yarn
+        run: npm install -g yarn
+      - run: yarn install --immutable
+      - run: npm version prepatch --preid=alpha
+      - run: yarn build
+      - run: npm publish

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -3,7 +3,7 @@ name: PR Checks
 on:
   push:
     branches:
-      - 'prerelease/**'
+      - "prerelease/**"
 
 jobs:
   code-format:
@@ -38,9 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-        name: Setup Node.js
         with:
-          node-version: "18.x"
+          node-version: "18"
+          registry-url: https://registry.npmjs.org
       - name: Setup yarn
         run: npm install -g yarn
       - run: yarn install --immutable

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -44,6 +44,5 @@ jobs:
       - name: Setup yarn
         run: npm install -g yarn
       - run: yarn install --immutable
-      - run: npm version prepatch --preid=alpha
       - run: yarn build
-      - run: npm publish
+      - run: npm publish --tag pre-release

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -1,9 +1,9 @@
-name: PR Checks
+name: Publish pre-release
 
 on:
   push:
-    branches:
-      - "prerelease/**"
+    tags:
+      - "pre-release-*"
 
 jobs:
   code-format:

--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -46,3 +46,5 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - run: npm publish --tag pre-release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -1,6 +1,7 @@
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "release-*"
 name: Publish to NPM
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/bluefin-v2-client",
-  "version": "5.2.47-alpha.1",
+  "version": "5.2.49",
   "description": "The Bluefin client Library allows traders to sign, create, retrieve and listen to orders on Bluefin Exchange.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/bluefin-v2-client",
-  "version": "5.2.47",
+  "version": "5.2.47-alpha.1",
   "description": "The Bluefin client Library allows traders to sign, create, retrieve and listen to orders on Bluefin Exchange.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Allow devs to publish a pre-release.

Current Process to release on npm is as follows
1. Go to github releases
2. Draft a new release
3. Create a release tag `release-*` and publish
4. Action triggers on release publish to publish the latest version to npm

After this PR:
1. Go to github releases 
2. To publish a pre-release create tag as `pre-release-*` 
3. To publish the latest release create tag as `release-*`
4. Actions triggers on tag creation and releases on npm accordingly