### PR TITLE
chore: bump library-sui to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluefin-exchange/bluefin-v2-client",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "The Bluefin client Library allows traders to sign, create, retrieve and listen to orders on Bluefin Exchange.",
   "main": "dist/index.js",
   "scripts": {
@@ -57,7 +57,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@firefly-exchange/library-sui": "^2.0.2",
+    "@firefly-exchange/library-sui": "^2.1.0",
     "@mysten/sui": "^1.12.0",
     "@mysten/zklogin": "^0.7.22",
     "@noble/hashes": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,10 +896,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@firefly-exchange/library-sui@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@firefly-exchange/library-sui/-/library-sui-2.0.3.tgz#77b41abea417349c6d09f1527d3c86e8f881f7c8"
-  integrity sha512-zZ07p67RPenX6oZ33HKLj3AzcG2lGmJvg0qYVcJGlswBq1A/LhgGOasvCHyHtO11p5EiQa8GU8BnOgzQveTtTA==
+"@firefly-exchange/library-sui@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@firefly-exchange/library-sui/-/library-sui-2.1.0.tgz#06819579e0e46b713403ef6943d9a631a3dfc505"
+  integrity sha512-6JOj1iut7OeTW9/U+gl/9U8TvGahrrzyPOgOgDXuVMLBLwIqbRDWwRp0j/ljPkhf1ir6PmBPYN783WAGGVLklA==
   dependencies:
     "@aws-sdk/client-kms" "^3.438.0"
     "@mysten/dapp-kit" "^0.14.25"


### PR DESCRIPTION
# Description

- Updates `library-sui` to version `2.1.0`

# Checklist:
- [x] All changes in this PR are at least one version backwards compatible, (reverting this PR is safe eg data migrations are backwards compatible).
- [x] I have performed a thorough self-review of my code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md, architecture docs, public docs, etc).
